### PR TITLE
Jimbo branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.Rproj
 *.html
 *_files*
+.Renviron

--- a/demoApp/R/semantic_search_helper_functions.R
+++ b/demoApp/R/semantic_search_helper_functions.R
@@ -109,6 +109,33 @@ generate_cluster_lookup <- function(example) {
 }
 
 
+# Embed query -------------------------------------------------------------
+
+embed_query <- function(query, embedding_model) {
+  
+  api_token <- Sys.getenv("HUGGINGFACE_API_KEY")
+  
+  base_hf_st_url <- "https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/"
+  
+  endpoint_hf_st <- embedding_model
+  
+  # Create the request
+  response <- request(base_hf_st_url) %>%
+    req_url_path_append(endpoint_hf_st) %>% 
+    req_headers(
+      "Authorization" = paste("Bearer", api_token)
+    ) %>%
+    req_body_json(query) %>%
+    req_perform()
+  
+  data <- resp_body_json(response) %>% 
+    unlist() %>% 
+    as.matrix()
+  
+  return(data)
+}
+
+
 # Cosine similarity calculation -------------------------------------------
 
 cosine_calculation_threshold_sentence <- function(reference_statement,
@@ -118,7 +145,7 @@ cosine_calculation_threshold_sentence <- function(reference_statement,
                                                   df) {
   ref_sentence <- reference_statement
   
-  reference_vector <- bt_do_embedding(embedding_model, ref_sentence)
+  reference_vector <- embed_query(query = ref_sentence, embedding_model = embedding_model)
   
   sentence_dot_products <- sentence_matrix %*% reference_vector
   

--- a/demoApp/modules/semantic_search_module.R
+++ b/demoApp/modules/semantic_search_module.R
@@ -33,7 +33,7 @@ semantic_searchServer <- function(id) {
       cosine_calculation_threshold_sentence(
         reference_statement = input$search_term,
         cosine_sim_threshold = input$cosine_sim_thresholds,
-        embedding_model = multi_qa_embedder,
+        embedding_model = "multi-qa-mpnet-base-cos-v1",
         sentence_matrix = multi_qa_matrix_sentences,
         df = example_sentences
       ) %>% 

--- a/renv.lock
+++ b/renv.lock
@@ -800,6 +800,11 @@
       ],
       "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
     },
+    "httr2": {
+      "Package": "httr2",
+      "Version": "1.0.1",
+      "Source": "Repository"
+    },
     "ids": {
       "Package": "ids",
       "Version": "1.0.1",


### PR DESCRIPTION
- Added the function that uses httr2 to call the Huggingface API for query embedding (and updated httr2 to the renv lockfile).
- Added a HF auth token to .Renviron and added to gitignore
- Updated the semantic_search_module and helper function to use this new function (query_embed()) rather than bt_do_embedding().
